### PR TITLE
Fix internalDestroy causing node crash

### DIFF
--- a/src/layers/Layer.js
+++ b/src/layers/Layer.js
@@ -24,8 +24,11 @@ function internalDestroy(layer, error) {
   layer.__contextToCallbackTimeouts.forEach((handle) => clearTimeout(handle));
   layer.__contextToCallbackTimeouts.clear(); // eslint-disable-line no-underscore-dangle
 
-  layer.__contextToCallback.forEach((cb) => cb(error)); // eslint-disable-line no-underscore-dangle
+  const callbacks = Array.from(layer.__contextToCallback.values());
   layer.__contextToCallback.clear(); // eslint-disable-line no-underscore-dangle
+  for (const cb of callbacks) {
+    try { cb(error); } catch (e) { /* swallow — destroy must not throw */ }
+  }
 
   layer.__idContext.clear(); // eslint-disable-line
 


### PR DESCRIPTION
I was gettings errors sometimes when connecting to some PLCs

```
node:internal/util/inspect:2160
2026-05-08T09:47:33: function formatWithOptionsInternal(inspectOptions, args) {
2026-05-08T09:47:33:                                   ^
2026-05-08T09:47:33: 
2026-05-08T09:47:33: RangeError: Maximum call stack size exceeded
2026-05-08T09:47:33:     at formatWithOptionsInternal (node:internal/util/inspect:2160:35)
2026-05-08T09:47:33:     at formatWithOptions (node:internal/util/inspect:2141:10)
2026-05-08T09:47:33:     at console.value (node:internal/console/constructor:343:14)
2026-05-08T09:47:33:     at console.log (node:internal/console/constructor:380:61)
2026-05-08T09:47:33:     at /client/node_modules/node-drivers/src/layers/cip/layers/internal/CIPConnectionLayer.js:102:19
2026-05-08T09:47:33:     at /client/node_modules/node-drivers/src/layers/Layer.js:275:43
2026-05-08T09:47:33:     at Map.forEach (<anonymous>)
2026-05-08T09:47:33:     at internalDestroy (/client/node_modules/node-drivers/src/layers/Layer.js:275:29)
2026-05-08T09:47:33:     at CIPConnectionLayer.destroy (/client/node_modules/node-drivers/src/layers/Layer.js:117:5)
2026-05-08T09:47:33:     at /client/node_modules/node-drivers/src/layers/cip/layers/internal/CIPConnectionLayer.js:103:16
2026-05-08T09:47:33: 

2026-05-08T09:52:07: node:internal/util/inspect:1618
2026-05-08T09:52:07: function formatPrimitive(fn, value, ctx) {
2026-05-08T09:52:07:                         ^
2026-05-08T09:52:07: 
2026-05-08T09:52:07: RangeError: Maximum call stack size exceeded
2026-05-08T09:52:07:     at formatPrimitive (node:internal/util/inspect:1618:25)
2026-05-08T09:52:07:     at formatValue (node:internal/util/inspect:770:12)
2026-05-08T09:52:07:     at inspect (node:internal/util/inspect:364:10)
2026-05-08T09:52:07:     at formatWithOptionsInternal (node:internal/util/inspect:2279:40)
2026-05-08T09:52:07:     at formatWithOptions (node:internal/util/inspect:2141:10)
2026-05-08T09:52:07:     at console.value (node:internal/console/constructor:343:14)
2026-05-08T09:52:07:     at console.log (node:internal/console/constructor:380:61)
2026-05-08T09:52:07:     at /client/node_modules/node-drivers/src/layers/cip/layers/internal/CIPConnectionLayer.js:102:19
2026-05-08T09:52:07:     at /client/node_modules/node-drivers/src/layers/Layer.js:275:43
2026-05-08T09:52:07:     at Map.forEach (<anonymous>)
2026-05-08T09:52:07: 

2026-05-08T10:05:27: node:internal/util/inspect:765
2026-05-08T10:05:27: function formatValue(ctx, value, recurseTimes, typedArray) {
2026-05-08T10:05:27:                     ^
2026-05-08T10:05:27: 
2026-05-08T10:05:27: RangeError: Maximum call stack size exceeded
2026-05-08T10:05:27:     at formatValue (node:internal/util/inspect:765:21)
2026-05-08T10:05:27:     at inspect (node:internal/util/inspect:364:10)
2026-05-08T10:05:27:     at formatWithOptionsInternal (node:internal/util/inspect:2279:40)
2026-05-08T10:05:27:     at formatWithOptions (node:internal/util/inspect:2141:10)
2026-05-08T10:05:27:     at console.value (node:internal/console/constructor:343:14)
2026-05-08T10:05:27:     at console.log (node:internal/console/constructor:380:61)
2026-05-08T10:05:27:     at /client/node_modules/node-drivers/src/layers/cip/layers/internal/CIPConnectionLayer.js:102:19
2026-05-08T10:05:27:     at /client/node_modules/node-drivers/src/layers/Layer.js:275:43
2026-05-08T10:05:27:     at Map.forEach (<anonymous>)
2026-05-08T10:05:27:     at internalDestroy (/client/node_modules/node-drivers/src/layers/Layer.js:275:29)
2026-05-08T10:05:27: 

2026-05-08T10:17:32: node:internal/validators:246
2026-05-08T10:17:32:   (value, name, options = null) => {
2026-05-08T10:17:32:   ^
2026-05-08T10:17:32: 
2026-05-08T10:17:32: RangeError: Maximum call stack size exceeded
2026-05-08T10:17:32:     at formatWithOptions (node:internal/util/inspect:2140:3)
2026-05-08T10:17:32:     at console.value (node:internal/console/constructor:343:14)
2026-05-08T10:17:32:     at console.log (node:internal/console/constructor:380:61)
2026-05-08T10:17:32:     at /client/node_modules/node-drivers/src/layers/cip/layers/internal/CIPConnectionLayer.js:102:19
2026-05-08T10:17:32:     at /client/node_modules/node-drivers/src/layers/Layer.js:275:43
2026-05-08T10:17:32:     at Map.forEach (<anonymous>)
2026-05-08T10:17:32:     at internalDestroy (/client/node_modules/node-drivers/src/layers/Layer.js:275:29)
2026-05-08T10:17:32:     at CIPConnectionLayer.destroy (/client/node_modules/node-drivers/src/layers/Layer.js:117:5)
2026-05-08T10:17:32:     at /client/node_modules/node-drivers/src/layers/cip/layers/internal/CIPConnectionLayer.js:103:16
```

I came to the conclusion that when the `ForwardClose` times out, `CIPConnectionLayer.js` calls `this.destroy('Forward Close error')`. That goes into `internalDestroy`, which iterates pending callbacks. One of them is the very same disconnect callback. Inside that callback, this.destroy(...) is called again, and because clear() happens after forEach, the map still contains the same callback, so it re-enters infinitely.

`internalDestroy` now clears the callback map before invoking, breaking the recursion.