### PR TITLE
Refresh apt cache before installing OpENer build deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - run: npm run test
       working-directory: node-drivers
 
-    - run: sudo apt-get install -y cmake binutils libcap-dev
+    - run: sudo apt-get update && sudo apt-get install -y cmake binutils libcap-dev
 
     - uses: actions/checkout@v4
       with:

--- a/test/integration/eip.js
+++ b/test/integration/eip.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { TCP, CIP } from '../../src/index';
+import { TCP, CIP } from '../../src/index.js';
 
 const tcpLayer = new TCP({ host: '127.0.0.1', port: 44818 });
 const eipLayer = new CIP.EIP(tcpLayer);


### PR DESCRIPTION
The hosted runner's apt index pinned libcap-dev to 2.66-5ubuntu2.2,
but the noble-updates mirror only carries a newer revision now, so
the install aborted with a 404 and exit code 100 before OpENer could
build. Run `apt-get update` first so the index points at versions
the mirror actually has.